### PR TITLE
Fix Row Colors with BootStrap 5

### DIFF
--- a/Southwind/Orders/OrdersClient.tsx
+++ b/Southwind/Orders/OrdersClient.tsx
@@ -37,7 +37,7 @@ export namespace OrdersClient {
           state == "Shipped" ? "gray" :
             "black";
   
-        return { style: { color: color } };
+        return { style: { "--bs-table-color" : color } as React.CSSProperties };
       }
     });
   


### PR DESCRIPTION
This fixes the Net9 framework update and the Bootstrap package issue. The SCSS are in use and override the main CSS properties. color.
