### PR TITLE
Fix - Change Autorun 'watcher' from Webpack to Vite

### DIFF
--- a/Southwind.Server/package.json
+++ b/Southwind.Server/package.json
@@ -38,7 +38,7 @@
   },
   "-vs-binding": {
     "ProjectOpened": [
-      "watch"
+      "dev"
     ]
   }
 }


### PR DESCRIPTION
Change the watcher to dev to autorun the "watcher" from Vite's